### PR TITLE
Add GroupCache, a new LRU optimized for removing related keys

### DIFF
--- a/2q.go
+++ b/2q.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/fxamacker/golang-lru/v2/simplelru"
 )
 
 const (

--- a/expirable/expirable_lru.go
+++ b/expirable/expirable_lru.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/internal"
+	"github.com/fxamacker/golang-lru/v2/internal"
 )
 
 // EvictCallback is used to get a callback when a cache entry is evicted

--- a/expirable/expirable_lru_test.go
+++ b/expirable/expirable_lru_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/fxamacker/golang-lru/v2/simplelru"
 )
 
 func BenchmarkLRU_Rand_NoExpire(b *testing.B) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/hashicorp/golang-lru/v2
+module github.com/fxamacker/golang-lru/v2
 
 go 1.19

--- a/group_lru.go
+++ b/group_lru.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lru
+
+import (
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+)
+
+// GroupCache is a thread-safe fixed size LRU cache.
+type GroupCache[G comparable, K comparable, V any] struct {
+	Cache[K, V]
+}
+
+// NewGroupCache creates an LRU with group of the given size.
+func NewGroupCache[G comparable, K comparable, V any](
+	size int,
+	groupFromKey func(K) G,
+) (*GroupCache[G, K, V], error) {
+	return NewGroupCacheWithEvict[G, K, V](size, groupFromKey, nil)
+}
+
+// NewGroupCacheWithEvict constructs a fixed size cache with the given eviction
+// callback.
+func NewGroupCacheWithEvict[G comparable, K comparable, V any](
+	size int,
+	groupFromKey func(K) G,
+	onEvicted func(key K, value V),
+) (c *GroupCache[G, K, V], err error) {
+	c = &GroupCache[G, K, V]{
+		Cache: Cache[K, V]{
+			onEvictedCB: onEvicted,
+		},
+	}
+	if onEvicted != nil {
+		c.initEvictBuffers()
+		onEvicted = c.onEvicted
+	}
+	c.lru, err = simplelru.NewGroupLRU(size, groupFromKey, onEvicted)
+	return
+}
+
+// RemoveGroup removes all keys associated with given group from the cache.
+func (c *GroupCache[G, K, V]) RemoveGroup(group G) (counter int) {
+	var ks []K
+	var vs []V
+	c.lock.Lock()
+	counter = c.lru.(*simplelru.GroupLRU[G, K, V]).RemoveGroup(group)
+	if c.onEvictedCB != nil && counter > 0 {
+		ks, vs = c.evictedKeys, c.evictedVals
+		c.initEvictBuffers()
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && counter > 0 {
+		for i := 0; i < len(ks); i++ {
+			c.onEvictedCB(ks[i], vs[i])
+		}
+	}
+	return
+}
+
+// RemoveGroups removes all keys associated with given groups from the cache.
+func (c *GroupCache[G, K, V]) RemoveGroups(groups []G) (counter int) {
+	var ks []K
+	var vs []V
+	c.lock.Lock()
+	counter = c.lru.(*simplelru.GroupLRU[G, K, V]).RemoveGroups(groups)
+	if c.onEvictedCB != nil && counter > 0 {
+		ks, vs = c.evictedKeys, c.evictedVals
+		c.initEvictBuffers()
+	}
+	c.lock.Unlock()
+	if c.onEvictedCB != nil && counter > 0 {
+		for i := 0; i < len(ks); i++ {
+			c.onEvictedCB(ks[i], vs[i])
+		}
+	}
+	return
+}

--- a/group_lru.go
+++ b/group_lru.go
@@ -4,7 +4,7 @@
 package lru
 
 import (
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/fxamacker/golang-lru/v2/simplelru"
 )
 
 // GroupCache is a thread-safe fixed size LRU cache.

--- a/group_lru_bench_test.go
+++ b/group_lru_bench_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lru
+
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkGroupCacheRemoveGroups(b *testing.B) {
+
+	type identifier [32]byte
+	type twoIdentifier [64]byte
+
+	const keyCountPerGroup = 5
+
+	groupFromKey := func(key twoIdentifier) identifier {
+		var group identifier
+		copy(group[:], key[:])
+		return group
+	}
+
+	benchmarks := []struct {
+		cacheSize   int
+		removeCount int
+	}{
+		{cacheSize: 1_000, removeCount: 25},
+		{cacheSize: 2_000, removeCount: 25},
+		{cacheSize: 3_000, removeCount: 25},
+		{cacheSize: 4_000, removeCount: 25},
+		{cacheSize: 5_000, removeCount: 25},
+		{cacheSize: 6_000, removeCount: 25},
+		{cacheSize: 7_000, removeCount: 25},
+		{cacheSize: 8_000, removeCount: 25},
+		{cacheSize: 9_000, removeCount: 25},
+		{cacheSize: 10_000, removeCount: 25},
+		{cacheSize: 20_000, removeCount: 25},
+	}
+
+	for _, bm := range benchmarks {
+		name := fmt.Sprintf("cache size %d, remove count %d", bm.cacheSize, bm.removeCount)
+		b.Run(name, func(b *testing.B) {
+			groupCount := bm.cacheSize/keyCountPerGroup + 1
+
+			groupIDs := make([]identifier, 0, groupCount)
+			keyIDs := make([]twoIdentifier, 0, groupCount*keyCountPerGroup)
+			for i := 0; i < groupCount; i++ {
+				var id identifier
+				_, _ = rand.Read(id[:])
+
+				groupIDs = append(groupIDs, id)
+
+				for j := 0; j < keyCountPerGroup; j++ {
+					var twoID twoIdentifier
+					_, _ = rand.Read(twoID[:])
+					copy(twoID[:], id[:])
+
+					keyIDs = append(keyIDs, twoID)
+				}
+			}
+
+			removeGroupCount := bm.removeCount / keyCountPerGroup
+
+			removeGroups := make([]identifier, removeGroupCount)
+			copy(removeGroups, groupIDs[len(groupIDs)-removeGroupCount:])
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+
+				cache, _ := NewGroupCache[identifier, twoIdentifier, struct{}](bm.cacheSize, groupFromKey)
+
+				for _, key := range keyIDs {
+					cache.Add(key, struct{}{})
+				}
+
+				b.StartTimer()
+
+				cache.RemoveGroups(removeGroups)
+			}
+		})
+	}
+}

--- a/group_lru_test.go
+++ b/group_lru_test.go
@@ -16,6 +16,7 @@ var groupFromKey = func(key int) string {
 	}
 }
 
+//gocyclo:ignore
 func TestGroupLRU(t *testing.T) {
 	evictCounter := 0
 	onEvicted := func(k int, v int) {

--- a/group_lru_test.go
+++ b/group_lru_test.go
@@ -1,0 +1,517 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package lru
+
+import (
+	"reflect"
+	"testing"
+)
+
+var groupFromKey = func(key int) string {
+	if key%2 == 0 {
+		return "even"
+	} else {
+		return "odd"
+	}
+}
+
+func TestGroupLRU(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k int, v int) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter++
+	}
+	l, err := NewGroupCacheWithEvict(128, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if l.Cap() != 128 {
+		t.Fatalf("expect %d, but %d", 128, l.Cap())
+	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad value: %v", v)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		if _, ok := l.Get(i); !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		l.Remove(i)
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("should be deleted")
+		}
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+// test that Add returns true/false if an eviction occurred
+func TestGroupLRUAdd(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k int, v int) {
+		evictCounter++
+	}
+
+	l, err := NewGroupCacheWithEvict(1, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+}
+
+// test that Contains doesn't update recent-ness
+func TestGroupLRUContains(t *testing.T) {
+	l, err := NewGroupCache[string, int, int](2, groupFromKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+}
+
+// test that ContainsOrAdd doesn't update recent-ness
+func TestGroupLRUContainsOrAdd(t *testing.T) {
+	l, err := NewGroupCache[string, int, int](2, groupFromKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	contains, evict := l.ContainsOrAdd(1, 1)
+	if !contains {
+		t.Errorf("1 should be contained")
+	}
+	if evict {
+		t.Errorf("nothing should be evicted here")
+	}
+
+	l.Add(3, 3)
+	contains, evict = l.ContainsOrAdd(1, 1)
+	if contains {
+		t.Errorf("1 should not have been contained")
+	}
+	if !evict {
+		t.Errorf("an eviction should have occurred")
+	}
+	if !l.Contains(1) {
+		t.Errorf("now 1 should be contained")
+	}
+}
+
+// test that PeekOrAdd doesn't update recent-ness
+func TestGroupLRUPeekOrAdd(t *testing.T) {
+	l, err := NewGroupCache[string, int, int](2, groupFromKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	previous, contains, evict := l.PeekOrAdd(1, 1)
+	if !contains {
+		t.Errorf("1 should be contained")
+	}
+	if evict {
+		t.Errorf("nothing should be evicted here")
+	}
+	if previous != 1 {
+		t.Errorf("previous is not equal to 1")
+	}
+
+	l.Add(3, 3)
+	contains, evict = l.ContainsOrAdd(1, 1)
+	if contains {
+		t.Errorf("1 should not have been contained")
+	}
+	if !evict {
+		t.Errorf("an eviction should have occurred")
+	}
+	if !l.Contains(1) {
+		t.Errorf("now 1 should be contained")
+	}
+}
+
+// test that Peek doesn't update recent-ness
+func TestGroupLRUPeek(t *testing.T) {
+	l, err := NewGroupCache[string, int, int](2, groupFromKey)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if v, ok := l.Peek(1); !ok || v != 1 {
+		t.Errorf("1 should be set to 1: %v, %v", v, ok)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("should not have updated recent-ness of 1")
+	}
+}
+
+// test that Resize can upsize and downsize
+func TestGroupLRUResize(t *testing.T) {
+	onEvictCounter := 0
+	onEvicted := func(k int, v int) {
+		onEvictCounter++
+	}
+	l, err := NewGroupCacheWithEvict(2, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Downsize
+	l.Add(1, 1)
+	l.Add(2, 2)
+	evicted := l.Resize(1)
+	if evicted != 1 {
+		t.Errorf("1 element should have been evicted: %v", evicted)
+	}
+	if onEvictCounter != 1 {
+		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Element 1 should have been evicted")
+	}
+
+	// Upsize
+	evicted = l.Resize(2)
+	if evicted != 0 {
+		t.Errorf("0 elements should have been evicted: %v", evicted)
+	}
+
+	l.Add(4, 4)
+	if !l.Contains(3) || !l.Contains(4) {
+		t.Errorf("Cache should have contained 2 elements")
+	}
+}
+
+func (c *GroupCache[G, K, V]) wantKeys(t *testing.T, want []K) {
+	t.Helper()
+	got := c.Keys()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wrong keys got: %v, want: %v ", got, want)
+	}
+}
+
+func TestGroupCache_EvictionSameKey(t *testing.T) {
+	t.Run("Add", func(t *testing.T) {
+		var evictedKeys []int
+
+		cache, _ := NewGroupCacheWithEvict(
+			2,
+			groupFromKey,
+			func(key int, _ struct{}) {
+				evictedKeys = append(evictedKeys, key)
+			})
+
+		if evicted := cache.Add(1, struct{}{}); evicted {
+			t.Error("First 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1})
+
+		if evicted := cache.Add(2, struct{}{}); evicted {
+			t.Error("2: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1, 2})
+
+		if evicted := cache.Add(1, struct{}{}); evicted {
+			t.Error("Second 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{2, 1})
+
+		if evicted := cache.Add(3, struct{}{}); !evicted {
+			t.Error("3: did not get expected eviction")
+		}
+		cache.wantKeys(t, []int{1, 3})
+
+		want := []int{2}
+		if !reflect.DeepEqual(evictedKeys, want) {
+			t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
+		}
+	})
+
+	t.Run("ContainsOrAdd", func(t *testing.T) {
+		var evictedKeys []int
+
+		cache, _ := NewGroupCacheWithEvict(
+			2,
+			groupFromKey,
+			func(key int, _ struct{}) {
+				evictedKeys = append(evictedKeys, key)
+			})
+
+		contained, evicted := cache.ContainsOrAdd(1, struct{}{})
+		if contained {
+			t.Error("First 1: got unexpected contained")
+		}
+		if evicted {
+			t.Error("First 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1})
+
+		contained, evicted = cache.ContainsOrAdd(2, struct{}{})
+		if contained {
+			t.Error("2: got unexpected contained")
+		}
+		if evicted {
+			t.Error("2: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1, 2})
+
+		contained, evicted = cache.ContainsOrAdd(1, struct{}{})
+		if !contained {
+			t.Error("Second 1: did not get expected contained")
+		}
+		if evicted {
+			t.Error("Second 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1, 2})
+
+		contained, evicted = cache.ContainsOrAdd(3, struct{}{})
+		if contained {
+			t.Error("3: got unexpected contained")
+		}
+		if !evicted {
+			t.Error("3: did not get expected eviction")
+		}
+		cache.wantKeys(t, []int{2, 3})
+
+		want := []int{1}
+		if !reflect.DeepEqual(evictedKeys, want) {
+			t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
+		}
+	})
+
+	t.Run("PeekOrAdd", func(t *testing.T) {
+		var evictedKeys []int
+
+		cache, _ := NewGroupCacheWithEvict(
+			2,
+			groupFromKey,
+			func(key int, _ struct{}) {
+				evictedKeys = append(evictedKeys, key)
+			})
+
+		_, contained, evicted := cache.PeekOrAdd(1, struct{}{})
+		if contained {
+			t.Error("First 1: got unexpected contained")
+		}
+		if evicted {
+			t.Error("First 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1})
+
+		_, contained, evicted = cache.PeekOrAdd(2, struct{}{})
+		if contained {
+			t.Error("2: got unexpected contained")
+		}
+		if evicted {
+			t.Error("2: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1, 2})
+
+		_, contained, evicted = cache.PeekOrAdd(1, struct{}{})
+		if !contained {
+			t.Error("Second 1: did not get expected contained")
+		}
+		if evicted {
+			t.Error("Second 1: got unexpected eviction")
+		}
+		cache.wantKeys(t, []int{1, 2})
+
+		_, contained, evicted = cache.PeekOrAdd(3, struct{}{})
+		if contained {
+			t.Error("3: got unexpected contained")
+		}
+		if !evicted {
+			t.Error("3: did not get expected eviction")
+		}
+		cache.wantKeys(t, []int{2, 3})
+
+		want := []int{1}
+		if !reflect.DeepEqual(evictedKeys, want) {
+			t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
+		}
+	})
+}
+
+func TestGroupCacheRemoveGroup(t *testing.T) {
+	const cacheSize = 128
+
+	testCases := []struct {
+		name             string
+		elementsToAdd    []int
+		groupsToRemove   []string
+		wantEvictEntries map[int]int
+	}{
+		{
+			name:             "remove group from empty cache",
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{},
+		},
+		{
+			name:             "remove non-existent group from cache",
+			elementsToAdd:    []int{0},
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{},
+		},
+		{
+			name:             "remove group with 1 key from cache",
+			elementsToAdd:    []int{0, 1, 2},
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{1: 1},
+		},
+		{
+			name:             "remove group with multiple keys from cache",
+			elementsToAdd:    []int{0, 1, 2},
+			groupsToRemove:   []string{"even"},
+			wantEvictEntries: map[int]int{0: 0, 2: 2},
+		},
+		{
+			name:           "remove group with all keys from cache",
+			elementsToAdd:  []int{0, 2, 4, 6, 8},
+			groupsToRemove: []string{"even"},
+			wantEvictEntries: map[int]int{
+				0: 0,
+				2: 2,
+				4: 4,
+				6: 6,
+				8: 8,
+			},
+		},
+		{
+			name:           "remove all groups",
+			elementsToAdd:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			groupsToRemove: []string{"even", "odd"},
+			wantEvictEntries: map[int]int{
+				0: 0,
+				2: 2,
+				4: 4,
+				6: 6,
+				8: 8,
+				1: 1,
+				3: 3,
+				5: 5,
+				7: 7,
+				9: 9,
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			evictEntries := make(map[int]int)
+			onEvicted := func(k int, v int) {
+				evictEntries[k] = v
+			}
+
+			l, err := NewGroupCacheWithEvict(cacheSize, groupFromKey, onEvicted)
+			if err != nil {
+				t.Fatalf("failed to create GroupLRU: %v", err)
+			}
+
+			for _, ele := range c.elementsToAdd {
+				evicted := l.Add(ele, ele)
+				if evicted {
+					t.Error("expect no eviction, got one")
+				}
+			}
+
+			var removeCounter int
+			if len(c.groupsToRemove) == 1 {
+				removeCounter = l.RemoveGroup(c.groupsToRemove[0])
+			} else {
+				removeCounter = l.RemoveGroups(c.groupsToRemove)
+			}
+
+			if removeCounter != len(c.wantEvictEntries) {
+				t.Errorf("expect %d removeCount, got %d", len(c.wantEvictEntries), removeCounter)
+			}
+
+			if !reflect.DeepEqual(evictEntries, c.wantEvictEntries) {
+				t.Errorf("expect evictEntries %v, got %v", c.wantEvictEntries, evictEntries)
+			}
+
+			if l.Len() != len(c.elementsToAdd)-len(c.wantEvictEntries) {
+				t.Errorf("expect lru len %d,  got %d", len(c.elementsToAdd)-len(c.wantEvictEntries), l.Len())
+			}
+
+			for _, ele := range c.elementsToAdd {
+				if _, evicted := c.wantEvictEntries[ele]; evicted {
+					if l.Contains(ele) {
+						t.Errorf("%d should not exist", ele)
+					}
+				} else {
+					v, ok := l.Peek(ele)
+					if !ok {
+						t.Errorf("%d should exist", ele)
+					} else if v != ele {
+						t.Errorf("%d should be set to %d", v, ele)
+					}
+				}
+			}
+		})
+	}
+}

--- a/lru.go
+++ b/lru.go
@@ -16,7 +16,7 @@ const (
 
 // Cache is a thread-safe fixed size LRU cache.
 type Cache[K comparable, V any] struct {
-	lru         *simplelru.LRU[K, V]
+	lru         simplelru.LRUCache[K, V]
 	evictedKeys []K
 	evictedVals []V
 	onEvictedCB func(k K, v V)

--- a/lru.go
+++ b/lru.go
@@ -6,7 +6,7 @@ package lru
 import (
 	"sync"
 
-	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/fxamacker/golang-lru/v2/simplelru"
 )
 
 const (

--- a/simplelru/group_lru.go
+++ b/simplelru/group_lru.go
@@ -1,0 +1,126 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package simplelru
+
+// GroupFromKey is used to get group from key.
+// This function is called when a cache entry is stored, removed, or evicted.
+type GroupFromKey[G, K comparable] func(key K) G
+
+// GroupLRU implements a non-thread safe fixed size LRU cache
+type GroupLRU[G comparable, K comparable, V any] struct {
+	*LRU[K, V]
+	groupFromKey GroupFromKey[G, K]
+	groups       map[G]map[K]struct{}
+}
+
+// NewGroupLRU constructs an LRU of the given size
+func NewGroupLRU[G comparable, K comparable, V any](
+	size int,
+	groupFromKey GroupFromKey[G, K],
+	onEvict EvictCallback[K, V],
+) (*GroupLRU[G, K, V], error) {
+	lru, err := NewLRU(size, onEvict)
+	if err != nil {
+		return nil, err
+	}
+	c := &GroupLRU[G, K, V]{
+		LRU:          lru,
+		groupFromKey: groupFromKey,
+		groups:       make(map[G]map[K]struct{}),
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *GroupLRU[G, K, V]) Purge() {
+	c.LRU.Purge()
+	c.groups = make(map[G]map[K]struct{})
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *GroupLRU[G, K, V]) Add(key K, value V) (evicted bool) {
+	// Add key and value to LRU cache
+	evictedKey, evicted := c.LRU.add(key, value)
+
+	// Add new key to groups.
+	c.addKeyToGroups(key)
+
+	if evicted {
+		// Remove evicted key from groups.
+		c.removeKeyFromGroups(evictedKey)
+	}
+	return evicted
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *GroupLRU[G, K, V]) Remove(key K) (present bool) {
+	present = c.LRU.Remove(key)
+	c.removeKeyFromGroups(key)
+	return
+}
+
+// RemoveGroup removes all keys associated with the given group and returns number of keys removed.
+func (c *GroupLRU[G, K, V]) RemoveGroup(group G) (count int) {
+	keys := c.groups[group]
+	count = len(keys)
+	for key := range keys {
+		c.LRU.Remove(key)
+	}
+	delete(c.groups, group)
+	return
+}
+
+// RemoveGroups removes all keys associated with the given groups and returns number of keys removed.
+func (c *GroupLRU[G, K, V]) RemoveGroups(groups []G) (count int) {
+	for _, group := range groups {
+		count += c.RemoveGroup(group)
+	}
+	return
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *GroupLRU[G, K, V]) RemoveOldest() (key K, value V, ok bool) {
+	key, value, ok = c.LRU.RemoveOldest()
+	c.removeKeyFromGroups(key)
+	return
+}
+
+// Resize changes the cache size.
+func (c *GroupLRU[G, K, V]) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		evictedKey, evicted := c.removeOldest()
+		if evicted {
+			c.removeKeyFromGroups(evictedKey)
+		}
+	}
+	c.size = size
+	return diff
+}
+
+func (c *GroupLRU[G, K, V]) addKeyToGroups(key K) {
+	group := c.groupFromKey(key)
+
+	keys := c.groups[group]
+	if keys == nil {
+		keys = make(map[K]struct{})
+		c.groups[group] = keys
+	}
+
+	keys[key] = struct{}{}
+}
+
+func (c *GroupLRU[G, K, V]) removeKeyFromGroups(key K) {
+	group := c.groupFromKey(key)
+
+	delete(c.groups[group], key)
+
+	if len(c.groups[group]) == 0 {
+		delete(c.groups, group)
+	}
+}

--- a/simplelru/group_lru.go
+++ b/simplelru/group_lru.go
@@ -3,6 +3,8 @@
 
 package simplelru
 
+import "errors"
+
 // GroupFromKey is used to get group from key.
 // This function is called when a cache entry is stored, removed, or evicted.
 type GroupFromKey[G, K comparable] func(key K) G
@@ -20,6 +22,9 @@ func NewGroupLRU[G comparable, K comparable, V any](
 	groupFromKey GroupFromKey[G, K],
 	onEvict EvictCallback[K, V],
 ) (*GroupLRU[G, K, V], error) {
+	if groupFromKey == nil {
+		return nil, errors.New("failed to create GroupCache: groupFromKey is nil")
+	}
 	lru, err := NewLRU(size, onEvict)
 	if err != nil {
 		return nil, err

--- a/simplelru/group_lru_test.go
+++ b/simplelru/group_lru_test.go
@@ -1,0 +1,423 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package simplelru
+
+import (
+	"reflect"
+	"testing"
+)
+
+var groupFromKey = func(key int) string {
+	if key%2 == 0 {
+		return "even"
+	} else {
+		return "odd"
+	}
+}
+
+func TestGroupLRU(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k int, v int) {
+		if k != v {
+			t.Fatalf("Evict values not equal (%v!=%v)", k, v)
+		}
+		evictCounter++
+	}
+	l, err := NewGroupLRU(128, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+		testGroupInSyncWithMainCache(t, l)
+	}
+	if l.Len() != 128 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if l.Cap() != 128 {
+		t.Fatalf("expect %d, but %d", 128, l.Cap())
+	}
+	if len(l.groups) != 2 {
+		t.Fatalf("expect %d groups, but %d groups", 2, len(l.groups))
+	}
+
+	if evictCounter != 128 {
+		t.Fatalf("bad evict count: %v", evictCounter)
+	}
+
+	for i, k := range l.Keys() {
+		if v, ok := l.Get(k); !ok || v != k || v != i+128 {
+			t.Fatalf("bad key: %v", k)
+		}
+	}
+	for i, v := range l.Values() {
+		if v != i+128 {
+			t.Fatalf("bad value: %v", v)
+		}
+	}
+	for i := 0; i < 128; i++ {
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("should be evicted")
+		}
+	}
+	for i := 128; i < 256; i++ {
+		if _, ok := l.Get(i); !ok {
+			t.Fatalf("should not be evicted")
+		}
+	}
+	for i := 128; i < 192; i++ {
+		if ok := l.Remove(i); !ok {
+			t.Fatalf("should be contained")
+		}
+		if ok := l.Remove(i); ok {
+			t.Fatalf("should not be contained")
+		}
+		if _, ok := l.Get(i); ok {
+			t.Fatalf("should be deleted")
+		}
+		testGroupInSyncWithMainCache(t, l)
+	}
+
+	l.Get(192) // expect 192 to be last key in l.Keys()
+
+	for i, k := range l.Keys() {
+		if (i < 63 && k != i+193) || (i == 63 && k != 192) {
+			t.Fatalf("out of order key: %v", k)
+		}
+	}
+
+	oddGroupLen := len(l.groups["odd"])
+	removedCount := l.RemoveGroup("odd")
+	if oddGroupLen != removedCount {
+		t.Fatalf("expect %d removed items from group %s, got %d", oddGroupLen, "odd", removedCount)
+	}
+	if len(l.groups) != 1 {
+		t.Fatalf("expect %d groups, got %d", 1, len(l.groups))
+	}
+
+	testGroupInSyncWithMainCache(t, l)
+
+	l.Purge()
+	if l.Len() != 0 {
+		t.Fatalf("bad len: %v", l.Len())
+	}
+	if len(l.groups) != 0 {
+		t.Fatalf("bad group len: %d", len(l.groups))
+	}
+	if _, ok := l.Get(200); ok {
+		t.Fatalf("should contain nothing")
+	}
+}
+
+func TestGroupLRU_GetOldest_RemoveOldest(t *testing.T) {
+	l, err := NewGroupLRU[string, int, int](128, groupFromKey, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	for i := 0; i < 256; i++ {
+		l.Add(i, i)
+		testGroupInSyncWithMainCache(t, l)
+	}
+	k, _, ok := l.GetOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k != 128 {
+		t.Fatalf("bad: %v", k)
+	}
+	testGroupInSyncWithMainCache(t, l)
+
+	k, _, ok = l.RemoveOldest()
+	if !ok {
+		t.Fatalf("missing")
+	}
+	if k != 129 {
+		t.Fatalf("bad: %v", k)
+	}
+	testGroupInSyncWithMainCache(t, l)
+}
+
+// Test that Add returns true/false if an eviction occurred
+func TestGroupLRU_Add(t *testing.T) {
+	evictCounter := 0
+	onEvicted := func(k int, v int) {
+		evictCounter++
+	}
+
+	l, err := NewGroupLRU(1, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if l.Add(1, 1) == true || evictCounter != 0 {
+		t.Errorf("should not have an eviction")
+	}
+	testGroupInSyncWithMainCache(t, l)
+	if l.Add(2, 2) == false || evictCounter != 1 {
+		t.Errorf("should have an eviction")
+	}
+	testGroupInSyncWithMainCache(t, l)
+}
+
+// Test that Contains doesn't update recent-ness
+func TestGroupLRU_Contains(t *testing.T) {
+	l, err := NewGroupLRU[string, int, int](2, groupFromKey, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	l.Add(1, 1)
+	l.Add(2, 2)
+	if !l.Contains(1) {
+		t.Errorf("1 should be contained")
+	}
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Contains should not have updated recent-ness of 1")
+	}
+
+	testGroupInSyncWithMainCache(t, l)
+}
+
+// Test that Resize can upsize and downsize
+func TestGroupLRU_Resize(t *testing.T) {
+	onEvictCounter := 0
+	onEvicted := func(k int, v int) {
+		onEvictCounter++
+	}
+	l, err := NewGroupLRU(2, groupFromKey, onEvicted)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Downsize
+	l.Add(1, 1)
+	l.Add(2, 2)
+	testGroupInSyncWithMainCache(t, l)
+
+	evicted := l.Resize(1)
+	if evicted != 1 {
+		t.Errorf("1 element should have been evicted: %v", evicted)
+	}
+	if onEvictCounter != 1 {
+		t.Errorf("onEvicted should have been called 1 time: %v", onEvictCounter)
+	}
+	testGroupInSyncWithMainCache(t, l)
+
+	l.Add(3, 3)
+	if l.Contains(1) {
+		t.Errorf("Element 1 should have been evicted")
+	}
+	testGroupInSyncWithMainCache(t, l)
+
+	// Upsize
+	evicted = l.Resize(2)
+	if evicted != 0 {
+		t.Errorf("0 elements should have been evicted: %v", evicted)
+	}
+	testGroupInSyncWithMainCache(t, l)
+
+	l.Add(4, 4)
+	if !l.Contains(3) || !l.Contains(4) {
+		t.Errorf("Cache should have contained 2 elements")
+	}
+	testGroupInSyncWithMainCache(t, l)
+}
+
+func (c *GroupLRU[G, K, V]) wantKeys(t *testing.T, want []K) {
+	t.Helper()
+	got := c.Keys()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wrong keys got: %v, want: %v ", got, want)
+	}
+}
+
+func TestGroupCache_EvictionSameKey(t *testing.T) {
+	var evictedKeys []int
+
+	cache, _ := NewGroupLRU(
+		2,
+		groupFromKey,
+		func(key int, _ struct{}) {
+			evictedKeys = append(evictedKeys, key)
+		})
+
+	if evicted := cache.Add(1, struct{}{}); evicted {
+		t.Error("First 1: got unexpected eviction")
+	}
+	cache.wantKeys(t, []int{1})
+	testGroupInSyncWithMainCache(t, cache)
+
+	if evicted := cache.Add(2, struct{}{}); evicted {
+		t.Error("2: got unexpected eviction")
+	}
+	cache.wantKeys(t, []int{1, 2})
+	testGroupInSyncWithMainCache(t, cache)
+
+	if evicted := cache.Add(1, struct{}{}); evicted {
+		t.Error("Second 1: got unexpected eviction")
+	}
+	cache.wantKeys(t, []int{2, 1})
+	testGroupInSyncWithMainCache(t, cache)
+
+	if evicted := cache.Add(3, struct{}{}); !evicted {
+		t.Error("3: did not get expected eviction")
+	}
+	cache.wantKeys(t, []int{1, 3})
+	testGroupInSyncWithMainCache(t, cache)
+
+	want := []int{2}
+	if !reflect.DeepEqual(evictedKeys, want) {
+		t.Errorf("evictedKeys got: %v want: %v", evictedKeys, want)
+	}
+}
+
+func TestGroupCache_RemoveGroup(t *testing.T) {
+	const cacheSize = 128
+
+	cases := []struct {
+		name             string
+		elementsToAdd    []int
+		groupsToRemove   []string
+		wantEvictEntries map[int]int
+	}{
+		{
+			name:             "remove group from empty cache",
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{},
+		},
+		{
+			name:             "remove non-existent group from cache",
+			elementsToAdd:    []int{0},
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{},
+		},
+		{
+			name:             "remove group with 1 key from cache",
+			elementsToAdd:    []int{0, 1, 2},
+			groupsToRemove:   []string{"odd"},
+			wantEvictEntries: map[int]int{1: 1},
+		},
+		{
+			name:             "remove group with multiple keys from cache",
+			elementsToAdd:    []int{0, 1, 2},
+			groupsToRemove:   []string{"even"},
+			wantEvictEntries: map[int]int{0: 0, 2: 2},
+		},
+		{
+			name:           "remove group with all keys from cache",
+			elementsToAdd:  []int{0, 2, 4, 6, 8},
+			groupsToRemove: []string{"even"},
+			wantEvictEntries: map[int]int{
+				0: 0,
+				2: 2,
+				4: 4,
+				6: 6,
+				8: 8,
+			},
+		},
+		{
+			name:           "remove all groups",
+			elementsToAdd:  []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			groupsToRemove: []string{"even", "odd"},
+			wantEvictEntries: map[int]int{
+				0: 0,
+				2: 2,
+				4: 4,
+				6: 6,
+				8: 8,
+				1: 1,
+				3: 3,
+				5: 5,
+				7: 7,
+				9: 9,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			evictEntries := make(map[int]int)
+			onEvicted := func(k int, v int) {
+				evictEntries[k] = v
+			}
+
+			l, err := NewGroupLRU(cacheSize, groupFromKey, onEvicted)
+			if err != nil {
+				t.Fatalf("failed to create GroupLRU: %v", err)
+			}
+
+			for _, ele := range c.elementsToAdd {
+				evicted := l.Add(ele, ele)
+				if evicted {
+					t.Error("expect no eviction, got one")
+				}
+				testGroupInSyncWithMainCache(t, l)
+			}
+
+			removeCounter := l.RemoveGroups(c.groupsToRemove)
+
+			testGroupInSyncWithMainCache(t, l)
+
+			if removeCounter != len(c.wantEvictEntries) {
+				t.Errorf("expect %d removeCount, got %d", len(c.wantEvictEntries), removeCounter)
+			}
+
+			if !reflect.DeepEqual(evictEntries, c.wantEvictEntries) {
+				t.Errorf("expect evictEntries %v, got %v", c.wantEvictEntries, evictEntries)
+			}
+
+			if l.Len() != len(c.elementsToAdd)-len(c.wantEvictEntries) {
+				t.Errorf("expect lru len %d,  got %d", len(c.elementsToAdd)-len(c.wantEvictEntries), l.Len())
+			}
+
+			for _, ele := range c.elementsToAdd {
+				if _, evicted := c.wantEvictEntries[ele]; evicted {
+					if l.Contains(ele) {
+						t.Errorf("%d should not exist", ele)
+					}
+				} else {
+					v, ok := l.Peek(ele)
+					if !ok {
+						t.Errorf("%d should exist", ele)
+					} else if v != ele {
+						t.Errorf("%d should be set to %d", v, ele)
+					}
+				}
+			}
+		})
+	}
+}
+
+func testGroupInSyncWithMainCache[G comparable, K comparable, V any](t *testing.T, c *GroupLRU[G, K, V]) {
+	// Test group cache size
+	groupCacheSize := 0
+	for group, keys := range c.groups {
+		groupCacheSize += len(keys)
+		if len(keys) == 0 {
+			t.Fatalf("found empty group %v", group)
+		}
+	}
+	if c.Len() != groupCacheSize {
+		t.Fatalf("cache size %d != group cache size %d", c.Len(), groupCacheSize)
+	}
+
+	// Test group cache content
+	for _, key := range c.Keys() {
+		group := c.groupFromKey(key)
+		if _, exists := c.groups[group][key]; !exists {
+			t.Fatalf("key %v doesn't exist in group %v", key, group)
+		}
+	}
+}

--- a/simplelru/group_lru_test.go
+++ b/simplelru/group_lru_test.go
@@ -16,6 +16,7 @@ var groupFromKey = func(key int) string {
 	}
 }
 
+//gocyclo:ignore
 func TestGroupLRU(t *testing.T) {
 	evictCounter := 0
 	onEvicted := func(k int, v int) {

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -48,11 +48,16 @@ func (c *LRU[K, V]) Purge() {
 
 // Add adds a value to the cache.  Returns true if an eviction occurred.
 func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
+	_, evicted = c.add(key, value)
+	return
+}
+
+func (c *LRU[K, V]) add(key K, value V) (evictedKey K, evicted bool) {
 	// Check for existing item
 	if ent, ok := c.items[key]; ok {
 		c.evictList.MoveToFront(ent)
 		ent.Value = value
-		return false
+		return
 	}
 
 	// Add new item
@@ -62,9 +67,9 @@ func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
 	evict := c.evictList.Length() > c.size
 	// Verify size not exceeded
 	if evict {
-		c.removeOldest()
+		return c.removeOldest()
 	}
-	return evict
+	return
 }
 
 // Get looks up a key's value from the cache.
@@ -166,10 +171,12 @@ func (c *LRU[K, V]) Resize(size int) (evicted int) {
 }
 
 // removeOldest removes the oldest item from the cache.
-func (c *LRU[K, V]) removeOldest() {
+func (c *LRU[K, V]) removeOldest() (evictedKey K, evicted bool) {
 	if ent := c.evictList.Back(); ent != nil {
 		c.removeElement(ent)
+		return ent.Key, true
 	}
+	return
 }
 
 // removeElement is used to remove a given list element from the cache

--- a/simplelru/lru.go
+++ b/simplelru/lru.go
@@ -6,7 +6,7 @@ package simplelru
 import (
 	"errors"
 
-	"github.com/hashicorp/golang-lru/v2/internal"
+	"github.com/fxamacker/golang-lru/v2/internal"
 )
 
 // EvictCallback is used to get a callback when a cache entry is evicted


### PR DESCRIPTION
GroupCache retains the fast speed of `Get` while also allowing the `delete-by-group` performance to be relatively stable even as number of total items in the cache grows.  The trade-off is to use some extra memory (cached keys).

For example, if we only know the key prefix (but not the entire key) we can use GroupCache to delete all keys from the cache having that prefix.  We can choose any criteria to group keys we want to delete. Using key prefix to group keys is just one example.

Basically, `lru.GroupCache` is an alternative to `lru.Cache`:
- `lru.Cache` can be used by components that don't need the `delete-by-group` feature
- `lru.GroupCache` is for use cases that need to delete a group of keys (by grouping keys by prefix or any other criteria)

More context at https://github.com/onflow/flow-go/issues/7383#issuecomment-3078688125

### hashicorp/golang-lru

Ideally, I would like to contribute this upstream to hashicorp/golang-lru.  There are [~19 open pull requests](https://github.com/hashicorp/golang-lru/pulls) upstream.

For now, I renamed this package name to `fxamacker/golang-lru` in go.mod to avoid using `replace` in case we need to use it before it gets accepted upstream.